### PR TITLE
Make sure there's a cache file before running the command. Closes #6.

### DIFF
--- a/lib/git-pulls.rb
+++ b/lib/git-pulls.rb
@@ -19,6 +19,11 @@ class GitPulls
 
   def run
     if @command && self.respond_to?(@command)
+      # If the cache file doesn't exist, make sure we run update
+      # before any other command. git-pulls will otherwise crash
+      # with an exception.
+      update unless File.exists?(PULLS_CACHE_FILE) || @command == 'update'
+
       self.send @command
     else
       help


### PR DESCRIPTION
When running git-pulls for the first time, it automatically updates the cache file before running any other command.
