### PR TITLE
Use launchy gem to open URL. Closes #7

### DIFF
--- a/git-pulls.gemspec
+++ b/git-pulls.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency     'json'
   s.add_runtime_dependency     'httparty'
+  s.add_runtime_dependency     'launchy'
 
   s.description       = <<desc
   git-pulls facilitates github pull requests.

--- a/lib/git-pulls.rb
+++ b/lib/git-pulls.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'json'
 require 'httparty'
+require 'launchy'
 require 'pp'
 
 class GitPulls
@@ -104,7 +105,7 @@ Usage: git pulls update
   def browse
     num = @args.shift
     if p = pull_num(num)
-      `open #{p['html_url']}`
+      Launchy.open(p['html_url'])
     else
       puts "No such number"
     end


### PR DESCRIPTION
This makes 'git pulls browse' platform-independent.
