### PR TITLE
Fix error with periods in repo names

### DIFF
--- a/lib/git-pulls.rb
+++ b/lib/git-pulls.rb
@@ -271,7 +271,7 @@ Usage: git pulls update
       c[k] = v
     end
     u = c['remote.origin.url']
-    if m = /github\.com.(.*?)\/(.*?)\.git/.match(u)
+    if m = /github\.com.(.*?)\/(.*)\.git/.match(u)
       user = m[1]
       proj = m[2]
     end


### PR DESCRIPTION
What the title says. Only matches up to the first period if they exist in a repo name (e.g. codykrieger.github.com.git turns into codykrieger.git).
