### PR TITLE
Add support for repositories cloned with no ".git" ending, e.g. https://github.com/schacon/git-pulls 

### DIFF
--- a/lib/git-pulls.rb
+++ b/lib/git-pulls.rb
@@ -253,9 +253,10 @@ Usage: git pulls update
       c[k] = v
     end
     u = c['remote.origin.url']
-    if m = /github\.com.(.*?)\/(.*)\.git/.match(u)
+    if m = /github\.com.(.*?)\/(.*)(\.git)?/.match(u)
       user = m[1]
       proj = m[2]
+      proj = proj[0..-5] if proj =~ /\.git$/
     end
     [user, proj]
   end


### PR DESCRIPTION
git-pulls failed for repositories cloned without the .git extension. This patch fixes that.
