### PR TITLE
Remove has_rdoc= method

### DIFF
--- a/git-pulls.gemspec
+++ b/git-pulls.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/schacon/git-pulls"
   s.email    = "schacon@gmail.com"
   s.authors  = ["Scott Chacon"]
-  s.has_rdoc = false
 
   s.files    = %w( LICENSE )
   s.files    += Dir.glob("lib/**/*")


### PR DESCRIPTION
This was throwing the following warning on rubygems 1.7:

> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.
