### PR TITLE
Ruby 1.9 compatibility

### DIFF
--- a/lib/git-pulls.rb
+++ b/lib/git-pulls.rb
@@ -285,7 +285,7 @@ Usage: git pulls update
     u = c['remote.origin.url']
 
     user, proj = github_user_and_proj(u)
-    if !(user and proj):
+    if !(user and proj)
       short, base = github_insteadof_matching(c, u)
       if short and base
         u = u.sub(short, base)


### PR DESCRIPTION
Hi,

I've removed one char (a `:` at the end of an `if` condition) so that git-pulls can run with Ruby 1.9.2.
