### PR TITLE
use an endpoint that works with private repositories

### DIFF
--- a/lib/git-pulls.rb
+++ b/lib/git-pulls.rb
@@ -167,7 +167,7 @@ Usage: git pulls update
         repos[repo] = true
       end
     end
-    if github_token
+    if github_credentials_provided?
       endpoint = "git@github.com:"
     else
       endpoint = github_endpoint + "/"


### PR DESCRIPTION
This allows fetch_stale_forks to avoid prompting for a password when using private repositories.  I tried finding a way to use github.host instead, but kept running into Octokit InvalidURIError's.
