### PR TITLE
Add [checkout] option that will create a branch for each open pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Makes it easy to list and merge GitHub pull requests.
     18   10/21 0  Some typos fixing.   mashingan:master
     19   10/26 0  Fix tag book link    ComputerDruid:fix-ta
 
+    $ git pulls checkout
+    Checking out all open pull requests for schacon/git-reference
+    > feature-request-1 into pull-feature-request-1
+    > feature/request2 into pull-feature/request2
+
     $ git pulls show 1
     > [summary]
     > [diffstat]

--- a/lib/git-pulls.rb
+++ b/lib/git-pulls.rb
@@ -37,7 +37,7 @@ class GitPulls
 
   def help
     puts "No command: #{@command}"
-    puts "Try: update, list, show, merge, browse"
+    puts "Try: update, list, show, merge, checkout, browse"
     puts "or call with '-h' for usage information"
   end
 
@@ -48,6 +48,7 @@ Usage: git pulls update
    or: git pulls show <number> [--full]
    or: git pulls browse <number>
    or: git pulls merge <number>
+   or: git pulls checkout [--force]
     USAGE
   end
 
@@ -125,9 +126,11 @@ Usage: git pulls update
 
   def list
     option = @args.shift
+
     puts "Open Pull Requests for #{@user}/#{@repo}"
     pulls = get_pull_info
     pulls.reverse! if option == '--reverse'
+
     count = 0
     pulls.each do |pull|
       line = []
@@ -144,6 +147,16 @@ Usage: git pulls update
     end
     if count == 0
       puts ' -- no open pull requests --'
+    end
+  end
+
+  def checkout
+    puts "Checking out all open pull requests for #{@user}/#{@repo}"
+    pulls = get_pull_info
+    pulls.each do |pull|
+      branch_ref = pull['head']['ref']
+      puts "> #{branch_ref} into pull-#{branch_ref}"
+      git("branch --track #{@args.join(' ')} pull-#{branch_ref} origin/#{branch_ref}")
     end
   end
 


### PR DESCRIPTION
My usual workflow at the start of the morning is to checkout each open pull request so I can do a local review of the code, run specs etc, before :+1:ing it.

This commit adds a `git pulls checkout` option, where any additional arguments are passed to the git branch command, for example '--force'.

I've also set a prefix to each branch name, to avoid any crossover with manual branches and easy grokking of the autogenerated ones to go through.
