### PR TITLE
Adds an env variable to specify a remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Makes it easy to list and merge GitHub pull requests.
 Requirements
 ------------
 
-`git-pulls` assumes you're using an 'origin' remote.  If you are not, simply add an 'origin'
-remote that points to the GitHub repository you want to check for pull requests.
+`git-pulls` assumes you're using an 'origin' remote.  If you are not,
+either add an 'origin' remote that points to the GitHub repository you want to check
+for pull requests, or set the name of your remote via an environment
+variable, GIT_REMOTE.
 
 Private repositories
 --------------------

--- a/lib/git-pulls.rb
+++ b/lib/git-pulls.rb
@@ -6,6 +6,7 @@ require 'octokit'
 
 class GitPulls
 
+  GIT_REMOTE = ENV['GIT_REMOTE'] || 'origin'
   GIT_PATH = lambda { return `git rev-parse --git-dir`.chomp }
   PULLS_CACHE_FILE = "#{GIT_PATH.call}/pulls_cache.json"
 
@@ -187,7 +188,7 @@ Usage: git pulls update
     pulls.each do |pull|
       branch_ref = pull['head']['ref']
       puts "> #{branch_ref} into pull-#{branch_ref}"
-      git("branch --track #{@args.join(' ')} pull-#{branch_ref} origin/#{branch_ref}")
+      git("branch --track #{@args.join(' ')} pull-#{branch_ref} #{GIT_REMOTE}/#{branch_ref}")
     end
   end
 
@@ -370,7 +371,7 @@ Usage: git pulls update
       k, v = line.split('=')
       c[k] = v
     end
-    u = c['remote.origin.url']
+    u = c["remote.#{GIT_REMOTE}.url"]
 
     user, proj = github_user_and_proj(u)
     if !(user and proj)


### PR DESCRIPTION
I often want to look at pull requests from remotes other than origin.
Often, I want to look at "upstream" (where origin is mine, and upstream
is the primary maintainer's) or other people's forks of my thing, etc.

Usage:
GIT_REMOTE=upstream git pulls list

or set it permanently in a profile or whatever.

Note, due to Issue #53, I can't actually use git-pulls yet, but someday...
